### PR TITLE
Support multiple worksheets, fixes #2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ same dialog to load a layer from a spreadsheet file with some options:
 * load geometry from x and y fields
 
 When dialog is accepted, it creates a new GDAL VRT file in same folder as the
-source data file, expanded with a *.vrt* suffix, which is loaded into QGIS.
+source data file and layer name, expanded with a *.vrt* suffix, which is
+loaded into QGIS.
 
 When reusing the same file twice, the dialog loads its values from the
 existing *.vrt* file.
@@ -69,7 +70,7 @@ and http://www.gdal.org/drv_xlsx.html.
 You can change this values in QGIS settings:
 
 - open *Settings* / *Options* dialog;
-- select *System* tab, and go to *Environnement* section;
+- select *System* tab, and go to *Environment* section;
 - check *Use custom variables*.
 - add a new line. Example:
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -14,7 +14,7 @@ qgisMinimumVersion=2.4
 description=Load layers from spreadsheet files (*.ods, *.xls, *.xlsx)
 about=This plugin adds a "Add spreadsheet layer" entry in "Layer" / "Add new Layer" menu and a corresponding button in the "Layers" toolbar.
     These two links open the same dialog to load a layer from a spreadsheet file (*.ods, *.xls, *.xlsx) with some options (use header at first line, ignore some rows and optionally load geometry from x and y fields).
-    When this dialog is accepted, it creates a new GDAL VRT file in same folder as the source data file, expanded with a .vrt suffix which is loaded into QGIS using OGR VRT driver.
+    When this dialog is accepted, it creates a new GDAL VRT file in same folder as the source data file and layer name, expanded with a .vrt suffix which is loaded into QGIS using OGR VRT driver.
     When reusing the same file twice, the dialog loads its values from the existing .vrt file.
     No need to install additional dependencies.
 version=1.0

--- a/widgets/SpreadsheetLayersDialog.py
+++ b/widgets/SpreadsheetLayersDialog.py
@@ -565,7 +565,7 @@ class SpreadsheetLayersDialog(QtGui.QDialog, Ui_SpreadsheetLayersDialog):
         return True
 
     def vrtPath(self):
-        return u'{}.vrt'.format(self.filePath())
+        return u'{}.{}.vrt'.format(self.filePath(), self.sheet())
 
     def samplePath(self):
         filename = u'{}.tmp.vrt'.format(os.path.basename(self.filePath()))


### PR DESCRIPTION
One workbook (data source) can have multiple worksheets (layers),
named using (e.g.) Book1.xlsx.Sheet1.vrt