### PR TITLE
Use LIMIT -1 when offset > 0 and EOF detection is off

### DIFF
--- a/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
+++ b/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
@@ -501,9 +501,14 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
             self._non_empty_rows = self.layer.GetFeatureCount()
 
     def sql(self):
-        sql = ("SELECT * FROM '{}'" " LIMIT {} OFFSET {}").format(
-            self.sheet(), self.limit(), self.offset()
-        )
+        if self.eofDetection() or self.offset() == 0:
+            sql = ("SELECT * FROM '{}'" " LIMIT {} OFFSET {}").format(
+                self.sheet(), self.limit(), self.offset()
+            )
+        else:
+            sql = ("SELECT * FROM '{}'" " LIMIT -1 OFFSET {}").format(
+                self.sheet(), self.offset()
+            )
         return sql
 
     def updateGeometry(self):


### PR DESCRIPTION
## Summary
- When skipping header rows (offset > 0) with EOF detection disabled, the hardcoded `LIMIT` in `SrcSql` prevented new rows added to the spreadsheet from appearing on reload
- Uses SQLite's `LIMIT -1` (unlimited) so only the `OFFSET` is applied
- No change to behaviour when EOF detection is on or when offset is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)