### PR TITLE
Add Spreadsheet Layers tab to the Data Source Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,2 @@
-*.swp
-*.pyc
-*~
-
-.build
 .pytest_cache
-dist
-SpreadsheetLayers/help
-.coverage
+tests/data/output/

--- a/SpreadsheetLayers/SpreadsheetLayersPlugin.py
+++ b/SpreadsheetLayers/SpreadsheetLayersPlugin.py
@@ -25,10 +25,12 @@ import os.path
 from importlib import resources
 
 from qgis.core import Qgis, QgsVectorLayer, QgsProject
+from qgis.gui import QgsGui
 from qgis.PyQt import QtCore, QtGui, QtWidgets
 
-# Import the code for the dialog
+# Import the code for the dialog (for the "showDialog" standalone flow)
 from .widgets.SpreadsheetLayersDialog import SpreadsheetLayersDialog
+from .widgets.sourceselect import SpreadsheetLayersSourceSelectProvider
 
 
 class SpreadsheetLayersPlugin(QtCore.QObject):
@@ -83,6 +85,11 @@ class SpreadsheetLayersPlugin(QtCore.QObject):
             self.iface.layerMenu().insertAction(action, self.action)
         self.iface.layerToolBar().addAction(self.action)
 
+        self.sourceSelectProvider = SpreadsheetLayersSourceSelectProvider()
+        QgsGui.instance().sourceSelectProviderRegistry().addProvider(
+            self.sourceSelectProvider
+        )
+
     def unload(self):
         if hasattr(self, "action"):
             if Qgis.QGIS_VERSION_INT > 20400:
@@ -90,6 +97,10 @@ class SpreadsheetLayersPlugin(QtCore.QObject):
             else:
                 self.iface.layerMenu().removeAction(self.action)
             self.iface.layerToolBar().removeAction(self.action)
+        if hasattr(self, "sourceSelectProvider"):
+            QgsGui.instance().sourceSelectProviderRegistry().removeProvider(
+                self.sourceSelectProvider
+            )
 
     def showDialog(self):
         dlg = SpreadsheetLayersDialog(self.iface.mainWindow())

--- a/SpreadsheetLayers/SpreadsheetLayersPlugin.py
+++ b/SpreadsheetLayers/SpreadsheetLayersPlugin.py
@@ -105,7 +105,7 @@ class SpreadsheetLayersPlugin(QtCore.QObject):
     def showDialog(self):
         dlg = SpreadsheetLayersDialog(self.iface.mainWindow())
         dlg.show()
-        if dlg.exec_():
+        if dlg.exec():
             layer = QgsVectorLayer(dlg.vrtPath(), dlg.layerName(), "ogr")
             layer.setProviderEncoding("UTF-8")
             if not layer.isValid():

--- a/SpreadsheetLayers/metadata.txt
+++ b/SpreadsheetLayers/metadata.txt
@@ -10,7 +10,8 @@
 
 [general]
 name=Spreadsheet Layers
-qgisMinimumVersion=3.0
+qgisMinimumVersion=3.44
+qgisMaximumVersion=4.99
 description=Load layers from spreadsheet files (*.ods, *.xls, *.xlsx)
 about=This plugin adds a "Add spreadsheet layer" entry in "Layer" / "Add new Layer" menu and a corresponding button in the "Layers" toolbar.
     These two links open the same dialog to load a layer from a spreadsheet file (*.ods, *.xls, *.xlsx) with some options (use header at first line, ignore some rows and optionally load geometry from x and y fields).

--- a/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
+++ b/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
@@ -55,15 +55,15 @@ class GeometryType(Enum):
 
 
 GEOMETRY_TYPES = (
-    (QgsWkbTypes.NoGeometry, GeometryType.wkbNone),
-    (QgsWkbTypes.Unknown, GeometryType.wkbUnknown),
-    (QgsWkbTypes.Point, GeometryType.wkbPoint),
-    (QgsWkbTypes.LineString, GeometryType.wkbLineString),
-    (QgsWkbTypes.Polygon, GeometryType.wkbPolygon),
-    (QgsWkbTypes.MultiPoint, GeometryType.wkbMultiPoint),
-    (QgsWkbTypes.MultiLineString, GeometryType.wkbMultiLineString),
-    (QgsWkbTypes.MultiPolygon, GeometryType.wkbMultiPolygon),
-    (QgsWkbTypes.GeometryCollection, GeometryType.wkbGeometryCollection),
+    (QgsWkbTypes.Type.NoGeometry, GeometryType.wkbNone),
+    (QgsWkbTypes.Type.Unknown, GeometryType.wkbUnknown),
+    (QgsWkbTypes.Type.Point, GeometryType.wkbPoint),
+    (QgsWkbTypes.Type.LineString, GeometryType.wkbLineString),
+    (QgsWkbTypes.Type.Polygon, GeometryType.wkbPolygon),
+    (QgsWkbTypes.Type.MultiPoint, GeometryType.wkbMultiPoint),
+    (QgsWkbTypes.Type.MultiLineString, GeometryType.wkbMultiLineString),
+    (QgsWkbTypes.Type.MultiPolygon, GeometryType.wkbMultiPolygon),
+    (QgsWkbTypes.Type.GeometryCollection, GeometryType.wkbGeometryCollection),
 )
 
 
@@ -81,11 +81,11 @@ class GeometryEncodingsModel(QtCore.QAbstractListModel):
     def rowCount(self, parent=QtCore.QModelIndex()):
         return len(self._encodings)
 
-    def data(self, index, role=QtCore.Qt.DisplayRole):
+    def data(self, index, role=QtCore.Qt.ItemDataRole.DisplayRole):
         encoding = self._encodings[index.row()]
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
             return encoding[0]
-        if role == QtCore.Qt.EditRole:
+        if role == QtCore.Qt.ItemDataRole.EditRole:
             return encoding[1]
 
 
@@ -95,15 +95,15 @@ class GeometryTypesModel(QtCore.QAbstractListModel):
     def rowCount(self, parent=QtCore.QModelIndex):
         return len(GEOMETRY_TYPES)
 
-    def data(self, index, role=QtCore.Qt.DisplayRole):
+    def data(self, index, role=QtCore.Qt.ItemDataRole.DisplayRole):
         geometry_type = GEOMETRY_TYPES[index.row()]
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
             if Qgis.QGIS_VERSION_INT >= 31800:
                 return QgsWkbTypes.translatedDisplayString(geometry_type[0])
             else:
                 return QgsWkbTypes.displayString(geometry_type[0])
 
-        if role == QtCore.Qt.EditRole:
+        if role == QtCore.Qt.ItemDataRole.EditRole:
             return geometry_type[1]
 
 
@@ -117,11 +117,11 @@ class FieldsModel(QtCore.QAbstractListModel):
     def rowCount(self, parent=QtCore.QModelIndex()):
         return len(self._fields)
 
-    def data(self, index, role=QtCore.Qt.DisplayRole):
+    def data(self, index, role=QtCore.Qt.ItemDataRole.DisplayRole):
         field = self._fields[index.row()]
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
             return field["name"]
-        if role == QtCore.Qt.EditRole:
+        if role == QtCore.Qt.ItemDataRole.EditRole:
             return field["src"]
 
 
@@ -180,37 +180,37 @@ class OgrTableModel(QtGui.QStandardItemModel):
         if fieldDefn.GetType() == ogr.OFTDate:
             if feature.IsFieldSet(iField):
                 value = datetime.date(*feature.GetFieldAsDateTime(iField)[:3])
-            hAlign = QtCore.Qt.AlignCenter
+            hAlign = QtCore.Qt.AlignmentFlag.AlignCenter
 
         elif fieldDefn.GetType() == ogr.OFTInteger:
             if feature.IsFieldSet(iField):
                 value = feature.GetFieldAsInteger(iField)
-            hAlign = QtCore.Qt.AlignRight
+            hAlign = QtCore.Qt.AlignmentFlag.AlignRight
 
         elif fieldDefn.GetType() == ogr.OFTReal:
             if feature.IsFieldSet(iField):
                 value = feature.GetFieldAsDouble(iField)
-            hAlign = QtCore.Qt.AlignRight
+            hAlign = QtCore.Qt.AlignmentFlag.AlignRight
 
         elif fieldDefn.GetType() == ogr.OFTString:
             if feature.IsFieldSet(iField):
                 value = feature.GetFieldAsString(iField)
-            hAlign = QtCore.Qt.AlignLeft
+            hAlign = QtCore.Qt.AlignmentFlag.AlignLeft
 
         else:
             if feature.IsFieldSet(iField):
                 value = feature.GetFieldAsString(iField)
-            hAlign = QtCore.Qt.AlignLeft
+            hAlign = QtCore.Qt.AlignmentFlag.AlignLeft
 
         if value is None:
             item = QtGui.QStandardItem("NULL")
-            item.setForeground(QtGui.QBrush(QtCore.Qt.gray))
+            item.setForeground(QtGui.QBrush(QtCore.Qt.GlobalColor.gray))
             font = item.font()
             font.setItalic(True)
             item.setFont(font)
         else:
             item = QtGui.QStandardItem(str(value))
-        item.setTextAlignment(hAlign | QtCore.Qt.AlignVCenter)
+        item.setTextAlignment(hAlign | QtCore.Qt.AlignmentFlag.AlignVCenter)
         return item
 
 
@@ -292,10 +292,10 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         self.sampleView.setItemDelegate(OgrFieldTypeDelegate())
 
     def info(self, msg):
-        self.messageBar.pushMessage(msg, Qgis.Info, 5)
+        self.messageBar.pushMessage(msg, Qgis.MessageLevel.Info, 5)
 
     def warning(self, msg):
-        self.messageBar.pushMessage(msg, Qgis.Warning, 5)
+        self.messageBar.pushMessage(msg, Qgis.MessageLevel.Warning, 5)
 
     def filePath(self):
         return self.filePathEdit.text()
@@ -360,7 +360,7 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         dataSource = ogr.Open(filePath, 0)
         if dataSource is None:
             self.messageBar.pushMessage(
-                "Could not open {}".format(filePath), Qgis.Warning, 5
+                "Could not open {}".format(filePath), Qgis.MessageLevel.Warning, 5
             )
         self.dataSource = dataSource
 
@@ -383,7 +383,7 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         dataSource = ogr.Open(filePath, 0)
         if dataSource is None:
             self.messageBar.pushMessage(
-                "Could not open {}".format(filePath), Qgis.Warning, 5
+                "Could not open {}".format(filePath), Qgis.MessageLevel.Warning, 5
             )
         self.sampleDatasource = dataSource
 
@@ -433,11 +433,11 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         self.updateSampleView()
 
     def header(self):
-        return self.headerBox.checkState() == QtCore.Qt.Checked
+        return self.headerBox.checkState() == QtCore.Qt.CheckState.Checked
 
     def setHeader(self, value):
         self.headerBox.setCheckState(
-            QtCore.Qt.Checked if value else QtCore.Qt.Unchecked
+            QtCore.Qt.CheckState.Checked if value else QtCore.Qt.CheckState.Unchecked
         )
 
     @QtCore.pyqtSlot(int)
@@ -465,11 +465,11 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         return self._non_empty_rows - self.offset()
 
     def eofDetection(self):
-        return self.eofDetectionBox.checkState() == QtCore.Qt.Checked
+        return self.eofDetectionBox.checkState() == QtCore.Qt.CheckState.Checked
 
     def setEofDetection(self, value):
         self.eofDetectionBox.setCheckState(
-            QtCore.Qt.Checked if value else QtCore.Qt.Unchecked
+            QtCore.Qt.CheckState.Checked if value else QtCore.Qt.CheckState.Unchecked
         )
 
     @QtCore.pyqtSlot(int)
@@ -529,11 +529,15 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def geometryEncoding(self):
         index = self.geometryEncodingComboBox.currentIndex()
-        return self.geometryEncodingComboBox.itemData(index, QtCore.Qt.EditRole)
+        return self.geometryEncodingComboBox.itemData(
+            index, QtCore.Qt.ItemDataRole.EditRole
+        )
 
     def setGeometryEncoding(self, value):
         self.geometryEncodingComboBox.setCurrentIndex(
-            self.geometryEncodingComboBox.findData(value, QtCore.Qt.EditRole)
+            self.geometryEncodingComboBox.findData(
+                value, QtCore.Qt.ItemDataRole.EditRole
+            )
         )
 
     @QtCore.pyqtSlot(int)
@@ -547,33 +551,37 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         index = self.geometryFieldComboBox.currentIndex()
         if index == -1:
             return ""
-        return self.geometryFieldComboBox.itemData(index, QtCore.Qt.EditRole)
+        return self.geometryFieldComboBox.itemData(
+            index, QtCore.Qt.ItemDataRole.EditRole
+        )
 
     def setGeometryField(self, fieldName):
         self.geometryFieldComboBox.setCurrentIndex(
-            self.geometryFieldComboBox.findData(fieldName, QtCore.Qt.EditRole)
+            self.geometryFieldComboBox.findData(
+                fieldName, QtCore.Qt.ItemDataRole.EditRole
+            )
         )
 
     def xField(self):
         index = self.xFieldBox.currentIndex()
         if index == -1:
             return ""
-        return self.xFieldBox.itemData(index, QtCore.Qt.EditRole)
+        return self.xFieldBox.itemData(index, QtCore.Qt.ItemDataRole.EditRole)
 
     def setXField(self, fieldName):
         self.xFieldBox.setCurrentIndex(
-            self.xFieldBox.findData(fieldName, QtCore.Qt.EditRole)
+            self.xFieldBox.findData(fieldName, QtCore.Qt.ItemDataRole.EditRole)
         )
 
     def yField(self):
         index = self.yFieldBox.currentIndex()
         if index == -1:
             return ""
-        return self.yFieldBox.itemData(index, QtCore.Qt.EditRole)
+        return self.yFieldBox.itemData(index, QtCore.Qt.ItemDataRole.EditRole)
 
     def setYField(self, fieldName):
         self.yFieldBox.setCurrentIndex(
-            self.yFieldBox.findData(fieldName, QtCore.Qt.EditRole)
+            self.yFieldBox.findData(fieldName, QtCore.Qt.ItemDataRole.EditRole)
         )
 
     def updateFieldBoxes(self):
@@ -627,11 +635,13 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
             return ""
         if self.geometryEncoding() == GeometryEncoding.PointFromColumns:
             return GeometryType.wkbPoint
-        return self.geometryTypeComboBox.itemData(index, QtCore.Qt.EditRole)
+        return self.geometryTypeComboBox.itemData(
+            index, QtCore.Qt.ItemDataRole.EditRole
+        )
 
     def setGeometryType(self, value):
         self.geometryTypeComboBox.setCurrentIndex(
-            self.geometryTypeComboBox.findData(value, QtCore.Qt.EditRole)
+            self.geometryTypeComboBox.findData(value, QtCore.Qt.ItemDataRole.EditRole)
         )
 
     def crs(self):
@@ -728,7 +738,7 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
                         raise ValueError(self.tr("Please select a geometry field"))
 
         except ValueError as e:
-            self.messageBar.pushMessage(str(e), Qgis.Warning, 5)
+            self.messageBar.pushMessage(str(e), Qgis.MessageLevel.Warning, 5)
             return False
 
         return True
@@ -749,7 +759,9 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
             return False
 
         file = QtCore.QFile(vrtPath)
-        if not file.open(QtCore.QIODevice.ReadOnly | QtCore.QIODevice.Text):
+        if not file.open(
+            QtCore.QIODevice.OpenModeFlag.ReadOnly | QtCore.QIODevice.OpenModeFlag.Text
+        ):
             self.warning("Impossible to open VRT file {}".format(vrtPath))
             return False
 
@@ -880,7 +892,7 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def prepareVrt(self, sample=False, without_fields=False):
         buffer = QtCore.QBuffer()
-        buffer.open(QtCore.QBuffer.ReadWrite)
+        buffer.open(QtCore.QBuffer.OpenModeFlag.ReadWrite)
 
         stream = QtCore.QXmlStreamWriter(buffer)
         stream.setAutoFormatting(True)
@@ -960,7 +972,10 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         vrtPath = self.vrtPath()
         file = QtCore.QFile(vrtPath)
         if file.exists():
-            if file.open(QtCore.QIODevice.ReadOnly | QtCore.QIODevice.Text):
+            if file.open(
+                QtCore.QIODevice.OpenModeFlag.ReadOnly
+                | QtCore.QIODevice.OpenModeFlag.Text
+            ):
                 oldContent = file.readAll()
                 file.close()
                 if content == oldContent:
@@ -970,15 +985,18 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
                 msgBox.setText("The file {} already exist.".format(vrtPath))
                 msgBox.setInformativeText("Do you want to overwrite ?")
                 msgBox.setStandardButtons(
-                    QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel
+                    QtWidgets.QMessageBox.StandardButton.Ok
+                    | QtWidgets.QMessageBox.StandardButton.Cancel
                 )
-                msgBox.setDefaultButton(QtWidgets.QMessageBox.Cancel)
-                ret = msgBox.exec_()
-                if ret == QtWidgets.QMessageBox.Cancel:
+                msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+                ret = msgBox.exec()
+                if ret == QtWidgets.QMessageBox.StandardButton.Cancel:
                     return False
             QtCore.QFile.remove(vrtPath)
 
-        if not file.open(QtCore.QIODevice.ReadWrite | QtCore.QIODevice.Text):
+        if not file.open(
+            QtCore.QIODevice.OpenModeFlag.ReadWrite | QtCore.QIODevice.OpenModeFlag.Text
+        ):
             self.warning("Impossible to open VRT file {}".format(vrtPath))
             return False
 
@@ -994,7 +1012,9 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         if file.exists():
             QtCore.QFile.remove(vrtPath)
 
-        if not file.open(QtCore.QIODevice.ReadWrite | QtCore.QIODevice.Text):
+        if not file.open(
+            QtCore.QIODevice.OpenModeFlag.ReadWrite | QtCore.QIODevice.OpenModeFlag.Text
+        ):
             self.warning("Impossible to open VRT file {}".format(vrtPath))
             return False
 

--- a/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
+++ b/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
@@ -642,15 +642,41 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
         crs.createFromString(authid)
         self.crsWidget.setCrs(crs)
 
+    def closePersistentEditors(self):
+        model = self.sampleView.model()
+        if model is not None:
+            for row in range(0, model.rowCount()):
+                for column in range(0, model.columnCount()):
+                    index = model.index(row, column)
+                    if self.sampleView.isPersistentEditorOpen(index):
+                        self.sampleView.closePersistentEditor(index)
+        # closePersistentEditor() only hides the editor widgets: delete any
+        # that are left in the viewport so they cannot pile up on every
+        # refresh of the sample table.
+        for editor in self.sampleView.viewport().findChildren(QtWidgets.QComboBox):
+            editor.setParent(None)
+            editor.deleteLater()
+
     def updateSampleView(self):
         if self.sampleRefreshDisabled:
             return
 
         self.updateGeometry()
 
+        # setModel(None) does not close persistent editors: they would stay
+        # in the viewport and accumulate on every refresh, corrupting the
+        # rendering of the table view (black sample area in the dialog).
+        self.closePersistentEditors()
+
         if self.layer is not None:
             self.writeSampleVrt()
             self.openSampleDatasource()
+        else:
+            # No sheet selected: do not fall back on a stale sample datasource
+            # (its fields would be empty while the sample model still has
+            # columns, crashing the field type delegate).
+            self.sampleView.setModel(None)
+            return
 
         layer = None
         dataSource = self.sampleDatasource

--- a/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
+++ b/SpreadsheetLayers/widgets/SpreadsheetLayersDialog.py
@@ -54,6 +54,10 @@ class GeometryType(Enum):
     wkbGeometryCollection = 9
 
 
+# QgsWkbTypes.Type.* uses scoped enum syntax required by PyQt6 (Qt6).
+# In PyQt5 the bare QgsWkbTypes.NoGeometry form also worked, but PyQt6
+# enforces the scoped form.  Keeping the scoped form ensures compatibility
+# with both Qt5 (QGIS 3.44) and Qt6 (QGIS 4.x).
 GEOMETRY_TYPES = (
     (QgsWkbTypes.Type.NoGeometry, GeometryType.wkbNone),
     (QgsWkbTypes.Type.Unknown, GeometryType.wkbUnknown),
@@ -790,7 +794,12 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
 
                 fields = []
 
-                while stream.readNext() != QtCore.QXmlStreamReader.EndDocument:
+                while (
+                    stream.readNext() != QtCore.QXmlStreamReader.TokenType.EndDocument
+                ):
+                    # NOTE: PyQt6 (Qt6) removed the unscoped QXmlStreamReader.EndDocument
+                    # enum, so the bare form raises AttributeError.  The scoped
+                    # TokenType.EndDocument works on both PyQt5 (Qt5) and PyQt6 (Qt6).
                     if stream.isComment():
                         text = stream.text()
                         pattern = re.compile(r"Header=(\w+)")
@@ -962,7 +971,7 @@ class SpreadsheetLayersDialog(QtWidgets.QDialog, FORM_CLASS):
 
         buffer.reset()
         content = buffer.readAll()
-        buffer.close
+        buffer.close()
 
         return content
 

--- a/SpreadsheetLayers/widgets/sourceselect.py
+++ b/SpreadsheetLayers/widgets/sourceselect.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ SpreadsheetLayersSourceSelect
+                                 A QGIS plugin
+ Load layers from MS Excel and OpenOffice spreadsheets
+                              -------------------
+        begin                : 2026-08-04
+        copyright            : (C) 2026 by Camptocamp
+        email                : info@camptocamp.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from importlib import resources
+
+from qgis.core import QgsProviderRegistry
+from qgis.gui import QgsAbstractDataSourceWidget, QgsSourceSelectProvider
+from qgis.PyQt import QtCore, QtGui, QtWidgets
+
+from SpreadsheetLayers.widgets.SpreadsheetLayersDialog import SpreadsheetLayersDialog
+
+
+class SpreadsheetLayersSourceSelect(QgsAbstractDataSourceWidget):
+    """Source select widget embedded in the Data Source Manager dialog.
+
+    It reuses the standalone SpreadsheetLayersDialog as a plain child widget
+    and relies on the Data Source Manager buttons to add the layer.
+    """
+
+    def __init__(self, parent=None, fl=QtCore.Qt.Widget, widgetMode=None):
+        if widgetMode is None:
+            widgetMode = QgsProviderRegistry.WidgetMode.Embedded
+        super().__init__(parent, fl, widgetMode)
+
+        self._layout = QtWidgets.QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._dialog = None
+        self._createDialog()
+
+    def _createDialog(self):
+        if self._dialog is not None:
+            self._layout.removeWidget(self._dialog)
+            self._dialog.setParent(None)
+            self._dialog.deleteLater()
+
+        self._dialog = SpreadsheetLayersDialog(self)
+        self._dialog.setWindowFlags(QtCore.Qt.Widget)
+        self._layout.addWidget(self._dialog)
+
+        # Turn the dialog button box into Add / Close / Help buttons and route
+        # the "Add" button to addButtonClicked() (same pattern as Delimited Text).
+        self.setupButtons(self._dialog.buttonBox)
+        help_button = self._dialog.buttonBox.button(QtWidgets.QDialogButtonBox.Help)
+        if help_button is not None:
+            help_button.hide()
+
+        # setupButtons() disables the "Add" button and only re-enables it
+        # through the enableButtons signal. Keep it enabled, validation is
+        # done when the button is clicked (same behaviour as the standalone
+        # dialog where the OK button is always active).
+        self.enableButtons.emit(True)
+
+    def addButtonClicked(self):
+        if not self._dialog.validate():
+            return
+        if not self._dialog.writeVrt():
+            return
+
+        datasource = self._dialog.vrtPath()
+        layer_name = self._dialog.layerName()
+        self.emit_addVectorLayer(datasource, layer_name)
+
+        if self.widgetMode() == QgsProviderRegistry.WidgetMode.Standalone:
+            self.accept()
+
+    def emit_addVectorLayer(self, datasource, layer_name):
+        # addVectorLayer is deprecated but remains the signal handled by the
+        # Data Source Manager in both QGIS 3.44 and 4.2 (see
+        # QgsDataSourceManagerDialog::makeConnections).
+        self.addVectorLayer.emit(datasource, layer_name, "ogr")
+
+    def reset(self):
+        # The Data Source Manager recycles this widget: it is created once and
+        # only reset() is called on every reopening of the dialog (see
+        # QgisApp::dataSourceManager). A reused Qt dialog is not repainted
+        # after being hidden and shown again (Qt 5.12+, e.g. under Wayland),
+        # leaving the page blank/black. Destroying and recreating the embedded
+        # dialog on each reset() guarantees a fresh widget is painted on every
+        # reopen.
+        self._createDialog()
+
+
+class SpreadsheetLayersSourceSelectProvider(QgsSourceSelectProvider):
+    """Provider adding a Spreadsheet Layers tab to the Data Source Manager."""
+
+    def providerKey(self):
+        return "spreadsheet"
+
+    def text(self):
+        return "Add Spreadsheet Layer\u2026"
+
+    def toolTip(self):
+        return "Add a layer from a spreadsheet file (*.ods, *.xls, *.xlsx)"
+
+    def icon(self):
+        icon_path = (
+            resources.files("SpreadsheetLayers")
+            / "resources"
+            / "icon"
+            / "mActionAddSpreadsheetLayer.svg"
+        )
+        return QtGui.QIcon(str(icon_path))
+
+    def ordering(self):
+        # Tabs are sorted by ascending ordering(). Native tabs use
+        # OrderLocalProvider=0, OrderDatabaseProvider=1000,
+        # OrderRemoteProvider=2000, OrderSearchProvider=4000 (e.g. the
+        # "metadata search" tab) and OrderOtherProvider=5000. Returning
+        # OrderSearchProvider - 1000 places the tab after the remote
+        # providers and just before the metadata search tab.
+        return QgsSourceSelectProvider.OrderSearchProvider - 1000
+
+    def createDataSourceWidget(self, parent=None, fl=QtCore.Qt.Widget, widgetMode=None):
+        if widgetMode is None:
+            widgetMode = QgsProviderRegistry.WidgetMode.Embedded
+        return SpreadsheetLayersSourceSelect(parent, fl, widgetMode)

--- a/SpreadsheetLayers/widgets/sourceselect.py
+++ b/SpreadsheetLayers/widgets/sourceselect.py
@@ -28,6 +28,11 @@ from qgis.PyQt import QtCore, QtGui, QtWidgets
 
 from SpreadsheetLayers.widgets.SpreadsheetLayersDialog import SpreadsheetLayersDialog
 
+# NOTE (Qt6 migration): all Qt enums use scoped form (Qt.WindowType.Widget,
+# QgsProviderRegistry.WidgetMode.Embedded, etc.) which is required by PyQt6
+# and also accepted by PyQt5, ensuring compatibility with both QGIS 3.44 and
+# QGIS 4.x.
+
 
 class SpreadsheetLayersSourceSelect(QgsAbstractDataSourceWidget):
     """Source select widget embedded in the Data Source Manager dialog.

--- a/SpreadsheetLayers/widgets/sourceselect.py
+++ b/SpreadsheetLayers/widgets/sourceselect.py
@@ -36,7 +36,7 @@ class SpreadsheetLayersSourceSelect(QgsAbstractDataSourceWidget):
     and relies on the Data Source Manager buttons to add the layer.
     """
 
-    def __init__(self, parent=None, fl=QtCore.Qt.Widget, widgetMode=None):
+    def __init__(self, parent=None, fl=QtCore.Qt.WindowType.Widget, widgetMode=None):
         if widgetMode is None:
             widgetMode = QgsProviderRegistry.WidgetMode.Embedded
         super().__init__(parent, fl, widgetMode)
@@ -53,13 +53,15 @@ class SpreadsheetLayersSourceSelect(QgsAbstractDataSourceWidget):
             self._dialog.deleteLater()
 
         self._dialog = SpreadsheetLayersDialog(self)
-        self._dialog.setWindowFlags(QtCore.Qt.Widget)
+        self._dialog.setWindowFlags(QtCore.Qt.WindowType.Widget)
         self._layout.addWidget(self._dialog)
 
         # Turn the dialog button box into Add / Close / Help buttons and route
         # the "Add" button to addButtonClicked() (same pattern as Delimited Text).
         self.setupButtons(self._dialog.buttonBox)
-        help_button = self._dialog.buttonBox.button(QtWidgets.QDialogButtonBox.Help)
+        help_button = self._dialog.buttonBox.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Help
+        )
         if help_button is not None:
             help_button.hide()
 
@@ -129,7 +131,9 @@ class SpreadsheetLayersSourceSelectProvider(QgsSourceSelectProvider):
         # providers and just before the metadata search tab.
         return QgsSourceSelectProvider.OrderSearchProvider - 1000
 
-    def createDataSourceWidget(self, parent=None, fl=QtCore.Qt.Widget, widgetMode=None):
+    def createDataSourceWidget(
+        self, parent=None, fl=QtCore.Qt.WindowType.Widget, widgetMode=None
+    ):
         if widgetMode is None:
             widgetMode = QgsProviderRegistry.WidgetMode.Embedded
         return SpreadsheetLayersSourceSelect(parent, fl, widgetMode)

--- a/tests/widgets/test_sourceselect.py
+++ b/tests/widgets/test_sourceselect.py
@@ -47,11 +47,15 @@ class TestSpreadsheetLayersSourceSelect(QgisTestCase):
         widget._dialog.setFilePath(path)
         widget._dialog.afterOpenFile()
 
+        vrt_path = os.path.join(OUTPUT_PATH, "x_y.ods.x_y.vrt")
+        if os.path.exists(vrt_path):
+            os.remove(vrt_path)
+
         with patch(
             "SpreadsheetLayers.widgets.SpreadsheetLayersDialog.SpreadsheetLayersDialog.vrtPath",
-            return_value=os.path.join(OUTPUT_PATH, "x_y.ods.x_y.vrt"),
+            return_value=vrt_path,
         ):
             widget.addButtonClicked()
 
-        assert os.path.exists(os.path.join(OUTPUT_PATH, "x_y.ods.x_y.vrt"))
+        assert os.path.exists(vrt_path)
         widget.deleteLater()

--- a/tests/widgets/test_sourceselect.py
+++ b/tests/widgets/test_sourceselect.py
@@ -1,0 +1,57 @@
+import os
+from unittest.mock import patch
+
+from qgis.gui import (
+    QgsAbstractDataSourceWidget,
+    QgsGui,
+    QgsSourceSelectProvider,
+)
+
+from tests import QgisTestCase
+from tests import INPUT_PATH, OUTPUT_PATH
+
+
+class TestSpreadsheetLayersSourceSelect(QgisTestCase):
+    def create_provider(self):
+        from SpreadsheetLayers.widgets.sourceselect import (
+            SpreadsheetLayersSourceSelectProvider,
+        )
+
+        return SpreadsheetLayersSourceSelectProvider()
+
+    def create_widget(self):
+        return self.create_provider().createDataSourceWidget(None)
+
+    def test_provider_returns_source_select_widget(self):
+        widget = self.create_widget()
+        assert isinstance(widget, QgsAbstractDataSourceWidget)
+        widget.deleteLater()
+
+    def test_provider_ordering_before_metadata_search(self):
+        provider = self.create_provider()
+        assert provider.ordering() == QgsSourceSelectProvider.OrderSearchProvider - 1000
+        assert provider.ordering() < QgsSourceSelectProvider.OrderSearchProvider
+
+    def test_provider_registration_in_registry(self):
+        registry = QgsGui.instance().sourceSelectProviderRegistry()
+        provider = self.create_provider()
+        registry.addProvider(provider)
+        try:
+            assert provider in registry.providers()
+        finally:
+            registry.removeProvider(provider)
+
+    def test_add_button_clicked_writes_vrt(self):
+        widget = self.create_widget()
+        path = os.path.join(INPUT_PATH, "x_y.ods")
+        widget._dialog.setFilePath(path)
+        widget._dialog.afterOpenFile()
+
+        with patch(
+            "SpreadsheetLayers.widgets.SpreadsheetLayersDialog.SpreadsheetLayersDialog.vrtPath",
+            return_value=os.path.join(OUTPUT_PATH, "x_y.ods.x_y.vrt"),
+        ):
+            widget.addButtonClicked()
+
+        assert os.path.exists(os.path.join(OUTPUT_PATH, "x_y.ods.x_y.vrt"))
+        widget.deleteLater()


### PR DESCRIPTION
Fixes #28

Adds an "Add Spreadsheet Layer…" tab to the Data Source Manager. The plugin is only reachable through the Layer menu / toolbar button. This PR also makes the plugin compatible with QGIS 4.x (Qt6/PyQt6) while keeping full support for QGIS 3.44 LTR (Qt5).

### Changes
- New `SpreadsheetLayersSourceSelectProvider` registered in `QgsSourceSelectProviderRegistry`, placed between the remote providers and the metadata search tab via `ordering()`.
- New embedded `SpreadsheetLayersSourceSelect` widget reusing the standalone dialog inside the DSM.
- Fixes for the blank/black page and stale sample-table editors when reopening the DSM (recreate the embedded dialog on `reset()`, close persistent editors before refreshing the model).
- Added unit tests for the source select and the VRT read/write round-trips.
- Qt6/PyQt6 migration: scoped enums (`Qt.ItemDataRole.*`, `Qt.WindowType.*`, `QgsWkbTypes.Type.*`, `QIODevice.OpenModeFlag.*`, `QXmlStreamReader.TokenType.*`, …), `exec()` instead of `exec_()`.
- `metadata.txt`: `qgisMinimumVersion=3.44`, `qgisMaximumVersion=4.99`.

### Testing
- **QGIS 3.44 LTR (Qt5)** : 11/11 unit tests pass; `black`, `flake8`, `bandit` clean.
- **QGIS 4.2 flatpak (Qt6)** : 11/11 unit tests pass; DSM tab order verified ("Add Spreadsheet Layer…" before "Recherche de métadonnées").

Tested on Linux Pop!_OS 24.04

### Checklist
- [X] No functional regression on QGIS 3.44 LTR
- [X] Works on QGIS 4.x (Qt6)
- [X] Tests and linters pass

