### PR TITLE
Run build and tests on QGIS 3.44 and QGIS 4.2 in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,13 +11,25 @@ on:
 
 env:
   HAS_SECRETS: ${{ secrets.HAS_SECRETS }}
+  # QGIS version used for the version independent steps (linters, transifex)
+  MAIN_QGIS_VERSION: '4.2'
 
 jobs:
   main:
     runs-on: ubuntu-24.04
-    name: Continuous integration
+    name: QGIS ${{ matrix.qgis-version }}
     timeout-minutes: 90
     if: "!startsWith(github.event.head_commit.message, '[skip ci] ')"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        qgis-version:
+          - '3.44'
+          - '4.2'
+
+    env:
+      QGIS_VERSION: ${{ matrix.qgis-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +39,7 @@ jobs:
 
       - name: Run linters
         run: make check
+        if: env.QGIS_VERSION == env.MAIN_QGIS_VERSION
 
       - name: Run automated tests suite
         run: make test
@@ -39,9 +52,11 @@ jobs:
         if: >
           github.ref == 'refs/heads/master'
           && env.HAS_SECRETS == 'HAS_SECRETS'
+          && env.QGIS_VERSION == env.MAIN_QGIS_VERSION
 
       - name: Push on transifex
         run: make tx-push
         if: >
           github.ref == 'refs/heads/master'
           && env.HAS_SECRETS == 'HAS_SECRETS'
+          && env.QGIS_VERSION == env.MAIN_QGIS_VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .pytest_cache
+__pycache__/
+dist
+docker/xauth
+SpreadsheetLayers/help
 tests/data/output/
+.coverage

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,10 +8,58 @@ Development install (linux)
 
    git clone git@github.com:camptocamp/QGIS-SpreadSheetLayers.git SpreadsheetLayers
    cd SpreadsheetLayers
-   ln -s ${PWD}/SpreadsheetLayers ~/.local/share/QGIS/QGIS3/profiles/default/python/plugins
-   make
+   make build
+   make link
 
 - run QGIS and activate SpreadsheetLayers plugin.
+
+The :code:`link` target creates the symbolic link in the QGIS profile
+directory given by :code:`QGISDIR`, which defaults to
+:code:`.local/share/QGIS/QGIS4/profiles/default` (relative to your
+:code:`$HOME`). Override it to target another QGIS version or profile:
+
+.. code::
+
+   make link QGISDIR=.local/share/QGIS/QGIS3/profiles/default
+
+Docker environment
+------------------
+
+Linters, tests and packaging run in a Docker image based on the official
+:code:`qgis/qgis` images. Build it with:
+
+.. code::
+
+   make docker-build
+
+The QGIS version defaults to the one set in the :code:`Makefile` and can be
+selected with the :code:`QGIS_VERSION` variable:
+
+.. code::
+
+   make docker-build test QGIS_VERSION=3.44
+
+Each version is tagged separately
+(:code:`camptocamp/qgis-spreadsheetlayers:<version>`), so images for several
+QGIS versions can coexist. To use a version for all the commands of your
+terminal session, export it:
+
+.. code::
+
+   export QGIS_VERSION=3.44
+
+Then run the checks and the tests suite:
+
+.. code::
+
+   make check
+   make test
+
+Or run QGIS desktop with the plugin loaded:
+
+.. code::
+
+   make qgis
 
 Release a new version
 ---------------------

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,15 @@
 ###################CONFIGURE HERE########################
 PLUGINNAME = SpreadsheetLayers
 
+# QGIS version of the docker image, can be overriden by calling
+# QGIS_VERSION=3.44 make <target> or in local.mk
+QGIS_VERSION ?= 4.2
+# QGIS_VERSION ?= 3.44
+
 #this can be overiden by calling QGIS_PREFIX_PATH=/my/path make
 # DEFAULT_QGIS_PREFIX_PATH=/usr/local/qgis-master
 DEFAULT_QGIS_PREFIX_PATH = /usr
-QGISDIR ?= .local/share/QGIS/QGIS3/profiles/default
+QGISDIR ?= .local/share/QGIS/QGIS4/profiles/default
 # QGISDIR ?= .local/share/QGIS/QGIS3/profiles/japanese
 # QGISDIR ?= .local/share/QGIS/QGIS3/profiles/french
 # QGISDIR ?= .local/share/QGIS/QGIS3/profiles/german
@@ -48,6 +53,9 @@ export QGIS_DEBUG_FILE=/dev/null
 endif
 
 export DOCKER_BUILDKIT=1
+
+# Used by docker-compose.yaml to select the image tag
+export QGIS_VERSION
 
 DOCKER_RUN_CMD = docker compose run --rm --user `id -u` tester
 
@@ -73,6 +81,8 @@ clean: ## Delete generated files
 
 .PHONY: qgis
 qgis: ## Run QGIS desktop
+	touch ./docker/xauth
+	xauth nlist ${DISPLAY} | sed -e 's/^..../ffff/' | xauth -f ./docker/xauth nmerge -
 	docker compose run --rm --user `id -u`:`id -g` --publish "5679:5679" qgis
 
 .PHONY: check
@@ -103,8 +113,11 @@ build: docker-build
 	$(DOCKER_RUN_CMD) make -f docker.mk build
 
 .PHONY: docker-build
-docker-build: ## Build docker images
-	docker build --tag camptocamp/qgis-spreadsheetlayers:latest ./docker
+docker-build: ## Build docker images (QGIS_VERSION=<version> to select the QGIS version)
+	docker build \
+		--build-arg QGIS_VERSION=$(QGIS_VERSION) \
+		--tag camptocamp/qgis-spreadsheetlayers:$(QGIS_VERSION) \
+		./docker
 
 
 ###############

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,34 +1,36 @@
 ---
 
-version: '2'
-
 volumes:
   qgis-settings:
 
 services:
 
   qgis:
-    image: camptocamp/qgis-spreadsheetlayers:latest
+    image: camptocamp/qgis-spreadsheetlayers:${QGIS_VERSION:-4.2}
     volumes:
       - ${PWD}/SpreadsheetLayers:/app/SpreadsheetLayers
       - ${PWD}/tests:/app/tests
       - /tmp/.X11-unix:/tmp/.X11-unix
-      - qgis-settings:/home/user/.local/share/QGIS/QGIS3/profiles/default
+      - qgis-settings:/home/user/.local/share/QGIS
+      - ./docker/xauth:/tmp/xauth:ro
+    devices:
+      - /dev/dri:/dev/dri
     environment:
       - PYTHONPATH=/app:/usr/share/qgis/python/plugins/
       - QGIS_DEBUG=0
       - QGIS_LOG_FILE=/dev/null
       - QGIS_PLUGINPATH=/app
-      - DISPLAY=unix${DISPLAY}
+      - DISPLAY=${DISPLAY}
+      - XAUTHORITY=/tmp/xauth
     entrypoint: ""
     command: qgis
 
   tester:
-    image: camptocamp/qgis-spreadsheetlayers:latest
+    image: camptocamp/qgis-spreadsheetlayers:${QGIS_VERSION:-4.2}
     volumes:
       - ${PWD}:/app
     environment:
-      - PYTHONPATH=/app:/usr/local/share/qgis/python:/usr/share/qgis/python/plugins/
+      - PYTHONPATH=/app:/usr/local/share/qgis/python:/usr/share/qgis/python:/usr/share/qgis/python/plugins/
       - QGIS_DEBUG=0
       - QGIS_LOG_FILE=/dev/null
       - QGIS_PLUGINPATH=/app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,11 @@
-FROM qgis/qgis:release-3_34
+ARG QGIS_VERSION=4.2
+FROM qgis/qgis:${QGIS_VERSION}
 
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache,sharing=locked \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
+        curl \
         git \
         make \
         pyqt5-dev-tools \
@@ -12,7 +14,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
 
 COPY requirements-dev.txt /tmp/requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache \
-    python3 -m pip install --disable-pip-version-check --requirement=/tmp/requirements-dev.txt
+    python3 -m pip install --disable-pip-version-check --break-system-packages --requirement=/tmp/requirements-dev.txt
 
 RUN curl -L -o /tmp/tx-linux-amd64.tar.gz https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz \
     && tar -C /usr/local/bin -xf /tmp/tx-linux-amd64.tar.gz tx \
@@ -22,10 +24,11 @@ RUN curl -L -o /tmp/tx-linux-amd64.tar.gz https://github.com/transifex/cli/relea
 RUN mkdir -p /app /home/user \
     && chmod 777 /home/user
 
-# Keep QGIS settings in a volume
-RUN mkdir -p /home/user/.local/share/QGIS/QGIS3/profiles/default \
+# Mounted as a volume by docker-compose to keep QGIS settings between runs.
+# QGIS creates the QGIS3/ or QGIS4/ subdirectory itself, so settings of
+# several QGIS versions can coexist in the same volume.
+RUN mkdir -p /home/user/.local/share/QGIS \
     && chmod -R 777 /home/user/.local
-VOLUME /home/user/.local/share/QGIS/QGIS3/profiles/default
 
 WORKDIR /app
 


### PR DESCRIPTION
Follow-up to #69: adapts the development environment to QGIS 4 while keeping QGIS 3.44 usable, and runs the build and the tests suite against both versions in CI.

No plugin code is changed, only the Docker environment, the `Makefile`, the CI workflow and the documentation.

## Docker environment

- `docker/Dockerfile` takes a `QGIS_VERSION` build arg (`FROM qgis/qgis:${QGIS_VERSION}`, default `4.2`) instead of the hardcoded `release-3_34`, and installs the dev requirements with `--break-system-packages`, required by the newer base images.
- Each QGIS version is tagged separately (`camptocamp/qgis-spreadsheetlayers:<version>`), so images for several versions can coexist. `docker-compose.yaml` picks the tag from `QGIS_VERSION`, exported by the `Makefile`.
- The QGIS settings volume moved up to `/home/user/.local/share/QGIS`: QGIS creates the `QGIS3/` or `QGIS4/` subdirectory itself, so the settings of both versions coexist in the same volume instead of clashing.
- `make qgis` now exports an X authority file (`docker/xauth`) and passes `/dev/dri` through, which is needed for the desktop to start.
- `docker-compose.yaml`: dropped the obsolete `version:` key, added `/usr/share/qgis/python` to `PYTHONPATH`.

## Makefile

- `QGIS_VERSION ?= 4.2`, overridable per command (`QGIS_VERSION=3.44 make test`) or in `local.mk`.
- `QGISDIR` defaults to the QGIS 4 profile path (`.local/share/QGIS/QGIS4/profiles/default`); override it to target another version or profile.

## CI

- `.github/workflows/main.yaml` gets a build matrix on `QGIS_VERSION` (`3.44` and `4.2`) with `fail-fast: false`, so `make build` and `make test` run against both versions and a failure on one leg does not cancel the other.
- The version independent steps (linters, transifex push) only run on the main version (`4.2`) to avoid duplicated reports and a double push.
- Note for reviewers: the job names change, they are now `QGIS 3.44` and `QGIS 4.2` instead of `Continuous integration`, so the required status check has to be updated in the branch protection rules.

## Documentation and misc

- `CONTRIBUTING.rst`: documented `make build` / `make link`, the `QGISDIR` override, the Docker environment and how to select the QGIS version.
- `.gitignore`: added the generated files that were missing (`__pycache__/`, `dist`, `docker/xauth`, `SpreadsheetLayers/help`, `.coverage`).

## Testing

Ran locally against both images: `make build` and `make test` pass on QGIS 3.44 and on QGIS 4.2 (11 tests).
